### PR TITLE
Do not create `self.Worker` in a window.

### DIFF
--- a/lib/message_channel.js
+++ b/lib/message_channel.js
@@ -8,6 +8,10 @@
     return functionToCheck && Object.prototype.toString.call(functionToCheck) === '[object Function]';
   }
 
+  function isInWorker() {
+    return  typeof Worker === 'undefined' && typeof Window === 'undefined'
+  }
+
   if( usePoly || !self.MessageChannel ) {
 
     var isWindowToWindowMessage = function( currentTarget ) {
@@ -535,23 +539,24 @@
 
       _overrideMessageEventListener( Worker.prototype );
 
-    } else {
-      // Web worker
+    } else if (isInWorker()) {
       self.Worker = { };
     }
 
-    self.Worker.postMessage = function( worker, message, transferList )  {
-      var data = MessageChannel.encodeEvent( message, transferList, false ),
-          entangledPort;
+    if (self.Worker) {
+      self.Worker.postMessage = function( worker, message, transferList )  {
+        var data = MessageChannel.encodeEvent( message, transferList, false ),
+            entangledPort;
 
-      for( var i=0 ; i<transferList.length ; i++) {
-        entangledPort = transferList[i]._getEntangledPort();
-        entangledPort._currentTarget = worker;
-      }
+        for( var i=0 ; i<transferList.length ; i++) {
+          entangledPort = transferList[i]._getEntangledPort();
+          entangledPort._currentTarget = worker;
+        }
 
-      MessageChannel.log(transferList, "handshake worker", worker);
-      worker.postMessage( data );
-    };
+        MessageChannel.log(transferList, "handshake worker", worker);
+        worker.postMessage( data );
+      };
+    }
   } else {
     if( Window ) {
       Window.postMessage = function( source, message, targetOrigin, ports ) {


### PR DESCRIPTION
`self.Worker` needs to be created in a web worker; in particular
`self.Worker.postMessage` is needed.  It is also needed in windows that
support web workers but lack `MessageChannel`.

However, for browsers that do not even support web workers, we do not want to 
create a `Worker` object as this may give false positives to feature
detection.

@Cyril-sf this look okay?
