### PR TITLE
Fix polyglot for firefox 30.0a1 (2014-02-17).

### DIFF
--- a/lib/message_channel.js
+++ b/lib/message_channel.js
@@ -510,7 +510,19 @@
         otherWindow.postMessage(data, targetOrigin);
       };
 
-      _overrideMessageEventListener( Window.prototype );
+      // Juggling to find where to override `addEventListener`
+      // Firefox 30.0a1 (2014-02-17) adds `addEventListener` on the global object
+      // Internet Explorer doesn't allow to override `window.attachEvent`
+      var target;
+      if( window.addEventListener ) {
+        target = window;
+      } else if( window.attachEvent ) {
+        target = Window.prototype;
+      } else {
+        throw "We couldn't find a method to attach an event handler."
+      }
+
+      _overrideMessageEventListener( target );
     } else {
       //Worker
       _overrideMessageEventListener( self );

--- a/lib/message_channel.js
+++ b/lib/message_channel.js
@@ -390,18 +390,16 @@
           messageHandlers = [];
 
       if( target.addEventListener ) {
-        originalAddEventListener = target.addEventListener;
         addEventListenerName = 'addEventListener';
-        targetRemoveEventListener = target.removeEventListener;
         removeEventListenerName = 'removeEventListener';
         messageEventType = 'message';
       } else if( target.attachEvent ) {
-        originalAddEventListener = target.attachEvent;
         addEventListenerName = 'attachEvent';
-        targetRemoveEventListener = target.detachEvent;
         removeEventListenerName = 'detachEvent';
         messageEventType = 'onmessage';
       }
+      originalAddEventListener = target[addEventListenerName];
+      targetRemoveEventListener = target[removeEventListenerName];
 
       target[addEventListenerName] = function() {
         var args = Array.prototype.slice.call( arguments ),

--- a/tests/tests/integration_test.js
+++ b/tests/tests/integration_test.js
@@ -117,7 +117,7 @@ test("Multiple message listeners can be added to a window", function() {
   addTrackedEventListener( messageHandler2 );
 
   stop();
-  self.Window.postMessage(window, 'test', host, []);
+  window.postMessage('test', host, []);
 });
 
 test("A message handler can be removed more than once", function() {


### PR DESCRIPTION
Apparently the WebIDL spec calls for `addEventListener` &c. to sit on the
global object.  I have not verified, but it doesn't make a difference: we can
just as easily extend `window` as `Window.prototype` and this will work with
the current
(and future) Firefox behaviour.

Fix #18.
