### PR TITLE
Fixed issue with messages missing event field in FF

### DIFF
--- a/lib/message_channel.js
+++ b/lib/message_channel.js
@@ -312,9 +312,10 @@
           },
           data = Kamino.parse( messageEvent.data ),
           event = data.event,
-          ports = event.ports;
+          ports;
 
       if( event ) {
+        ports = event.ports;
         if( ports ) {
           for(var i=0; i< ports.length ; i++) {
             fakeEvent.ports.push( MessagePort.prototype._getPort( ports[i], messageEvent, copyEvents ) );
@@ -323,6 +324,8 @@
         fakeEvent.data = event.data;
         fakeEvent.source = messageEvent.source;
         fakeEvent.messageChannel = event.messageChannel;
+      } else {
+        return messageEvent;
       }
 
       return fakeEvent;

--- a/package.json
+++ b/package.json
@@ -23,6 +23,6 @@
     "gfms": "~0.0.7"
   },
   "dependencies": {
-    "bower": "~1.2.6"
+    "bower": "~1.4.1"
   }
 }

--- a/tests/fixtures/differently_encoded_message.html
+++ b/tests/fixtures/differently_encoded_message.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Parent iFrame</title>
+  <script src="/vendor/jquery-1.9.1.min.js"></script>
+</head>
+<body>
+  <script type="text/javascript">
+    var loadHandler = function( event ) {
+      window.parent.postMessage( '{"look_ma":"no event field"}', "*", [] );
+    };
+
+    $( document ).ready( loadHandler );
+  </script>
+  <ul></ul>
+</body>
+</html>

--- a/tests/tests/integration_test.js
+++ b/tests/tests/integration_test.js
@@ -156,6 +156,28 @@ test("A user agent can receive unencoded messages", function() {
   document.body.appendChild( iFrame );
 });
 
+test("A user agent can receive a parseable object with no event field", function() {
+  expect(1);
+  var host = window.location.protocol + "//" + window.location.hostname,
+      iFramePort = parseInt(window.location.port, 10) + 1,
+      iFrameOrigin = host + ':' + iFramePort,
+      iFrameURL = iFrameOrigin + "/tests/fixtures/differently_encoded_message.html",
+      iFrame;
+
+  iFrame = document.createElement('iframe');
+  iFrame.setAttribute('src', iFrameURL);
+
+  var messageHandler = function( event ) {
+    equal( event.data, '{"look_ma":"no event field"}', 'An encoded event by another library can be received');
+    start();
+  };
+
+  addTrackedEventListener( messageHandler );
+
+  stop();
+  document.body.appendChild( iFrame );
+});
+
 QUnit.module("MessageChannel - event propagation", {
   teardown: function() {
     if( MessageChannel.reset ) {


### PR DESCRIPTION
Looks like in the latest Firefox MessageChannel is still being 
supplanted by this library, however because MessagePort is implemented 
frames without MessageChannel.js are pushing valid 
MessageEvents.  As a result decodeEvent is receiving a legitimate 
MessageEvent that does not need to be faked.  For these events, just 
pass them on as-is to avoid an ‘event is undefined’ error in the 
decoding.
